### PR TITLE
Fix wording

### DIFF
--- a/draft-thomson-tls-keylogfile.md
+++ b/draft-thomson-tls-keylogfile.md
@@ -61,7 +61,7 @@ This document describes the SSLKEYLOGFILE format.  This format can be used for
 TLS 1.2 {{!TLS12=RFC5246}} and TLS 1.3 {{!TLS13=RFC8446}}.  The format also
 supports earlier TLS versions, though use of earlier versions is forbidden
 {{?RFC8996}}.  This format can also be used with DTLS {{?DTLS13=RFC9147}}, QUIC
-{{?RFC9000}}{{?RFC9001}}, and protocols that also use the TLS key schedule.  Use
+{{?RFC9000}}{{?RFC9001}}, and other protocols that also use the TLS key schedule.  Use
 of this format could complement other protocol-specific logging such as QLOG
 {{?QLOG=I-D.ietf-quic-qlog-main-schema}}.
 


### PR DESCRIPTION
The current wording implies that DTLS and QUIC do not use the TLS key schedule.